### PR TITLE
Create the temporary file in $TMPDIR.

### DIFF
--- a/imgopt
+++ b/imgopt
@@ -266,7 +266,7 @@ do
     usage
     exit
   fi
-  TMPF=$(mktemp imgopt.tmp.XXXXXX)
+  TMPF=$(mktemp -t imgopt.tmp.XXXXXX)
   RETURNVAL=1
   if [[ -d "${arg}" ]]
   then


### PR DESCRIPTION
Currently imgopt creates the $TMPF file in the current working directory. However, I don't always have write access to that so it would be preferable to always use $TMPDIR I think.